### PR TITLE
fix: replaced user env variable by hardcoded name.

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -209,7 +209,7 @@ function maybe_prompt_user() {
 }
 
 heading "Add user to dialout group to allow managing serial ports"
-usermod -a -G dialout $USER
+usermod -a -G dialout root
 echo "Done!"
 
 # Add back python symlink to python interpreter on Ubuntu >= 20.04


### PR DESCRIPTION
For some reason usermod -a -G dialout $USER was not working while building our dev container. So, I just replaced $USER by root and this will make it work.